### PR TITLE
export `runQueryWithOptions`

### DIFF
--- a/src/Network/GraphQL/Client.hs
+++ b/src/Network/GraphQL/Client.hs
@@ -7,6 +7,7 @@
 
 module Network.GraphQL.Client
   ( runQuery
+  , runQueryWithOptions
   , W.Auth(..)
   , tlsManagerSettings
   , newManager


### PR DESCRIPTION
In order to use use X-Authorization as a header in a graphql request, export the more general `runQueryWithOptions` function.

See [SRC-197](https://superrare.atlassian.net/browse/SRC-197).